### PR TITLE
style: set default background color to white in category page

### DIFF
--- a/FrontEnd/pages/category.php
+++ b/FrontEnd/pages/category.php
@@ -31,6 +31,10 @@ if (isset($_SESSION['user'])) {
     <link rel="stylesheet" href="../Style/main.css">
     <link rel="stylesheet" href="../Style/add-to-cart.css"> 
     <style>
+        body {
+            background-color: white !important;
+        }
+        
         .wishlist-icon {
             cursor: pointer;
             transition: color 0.3s ease;


### PR DESCRIPTION
The background color was explicitly set to white to ensure consistency across all browsers and devices, overriding any potential inherited styles